### PR TITLE
Add jdk11 dependency to Ubuntu-18.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,16 @@ workflows:
     - test:
         name: test-ubuntu1804
         tag: ubuntu1804
-        ref: refs/heads/master
+        ref: refs/heads/4.13
+        param: ""
+        filters:
+          branches:
+            ignore: master
+    
+    - test:
+        name: test-ubuntu1804-jdk11
+        tag: ubuntu1804-jdk11
+        ref: refs/heads/4.15
         param: ""
         filters:
           branches:
@@ -106,6 +115,13 @@ workflows:
     - push:
         name: push-ubuntu1804
         tag: ubuntu1804
+        filters:
+          branches:
+            only: master
+    
+    - push:
+        name: push-ubuntu1804-jdk11
+        tag: ubuntu1804-jdk11
         filters:
           branches:
             only: master

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-.PHONY: all ubuntu1404 ubuntu1604 ubuntu1804 latest
+.PHONY: all ubuntu1404 ubuntu1604 ubuntu1804 ubuntu1804-jdk11 latest
 
 # Build docker tag based on provided info
 #
@@ -35,6 +35,9 @@ ubuntu1604:
 
 ubuntu1804:
 	$(call build_tag,ubuntu1804,ubuntu1804)
+
+ubuntu1804-jdk11:
+	$(call build_tag,ubuntu1804-jdk11,ubuntu1804-jdk11)
 
 latest:
 	$(call build_tag,latest,ubuntu1804)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This will give portable, immutable and reproducable mechanism to build packages 
 ## Supported tags and respective `Dockerfile` links
 
 - [`latest`, `ubuntu1804` (ubuntu1804/Dockerfile)](https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1804/Dockerfile)
+- [`ubuntu1804-jdk11` (ubuntu1804-jdk11/Dockerfile)](https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1804-jdk11/Dockerfile)
 - [`ubuntu1604` (ubuntu1604/Dockerfile)](https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1604/Dockerfile)
 - [`ubuntu1404` (ubuntu1404/Dockerfile)](https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1404/Dockerfile)
 

--- a/ubuntu1404/Dockerfile
+++ b/ubuntu1404/Dockerfile
@@ -53,5 +53,6 @@ WORKDIR /mnt/build
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY environment-info.sh /usr/local/bin/environment-info.sh
+COPY settings.xml /etc/maven/settings.xml
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/ubuntu1404/settings.xml
+++ b/ubuntu1404/settings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <profiles>
+    <profile>
+        <id>maven-https</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <repositories>
+            <repository>
+                <id>central</id>
+                <url>https://repo1.maven.org/maven2</url>
+                <snapshots>
+                    <enabled>false</enabled>
+                </snapshots>
+            </repository>
+        </repositories>
+        <pluginRepositories>
+            <pluginRepository>
+                <id>central</id>
+                <url>https://repo1.maven.org/maven2</url>
+                <snapshots>
+                    <enabled>false</enabled>
+                </snapshots>
+            </pluginRepository>
+        </pluginRepositories> 
+    </profile>
+  </profiles>
+</settings>

--- a/ubuntu1804-jdk11/Dockerfile
+++ b/ubuntu1804-jdk11/Dockerfile
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:18.04
+LABEL maintainer="Khosrow Moossavi <me@khosrow.io> (@khos2ow)"
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        make \
+        locate \
+        tar \
+        lsb-release \
+        build-essential \
+        dpkg-dev \
+        devscripts \
+        debhelper \
+        genisoimage \
+        git \
+        maven \
+        openjdk-11-jdk \
+        python \
+        python-mysqldb \
+        python-mysql.connector \
+        dh-systemd \
+        python-setuptools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.11.0-openjdk-amd64
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+VOLUME /mnt/build
+WORKDIR /mnt/build
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY environment-info.sh /usr/local/bin/environment-info.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/ubuntu1804-jdk11/Dockerfile
+++ b/ubuntu1804-jdk11/Dockerfile
@@ -36,7 +36,12 @@ RUN apt-get update -y && \
         python-mysqldb \
         python-mysql.connector \
         dh-systemd \
-        python-setuptools && \
+        python-setuptools \
+        curl \
+        sudo && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
+    apt-get install -y --no-install-recommends \
+        nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     update-java-alternatives -s java-1.11.0-openjdk-amd64

--- a/ubuntu1804-jdk11/docker-entrypoint.sh
+++ b/ubuntu1804-jdk11/docker-entrypoint.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# Flag to show help text
+show_help=false
+
+# Workspace path
+workspace_path=""
+
+# Using remote git repository variables
+use_remote=false
+git_remote=""
+git_ref=""
+remove_first=false
+
+# packaging flags to be sent to script
+PKG_ARGS=""
+HELP_ARG=""
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --git-remote)
+            if [ -n "$git_remote" ]; then
+                echo "Error: you have already entered value for --git-remote"
+                exit 1
+            else
+                git_remote=$2
+                use_remote=true
+                shift 2
+            fi
+            ;;
+
+        --git-ref)
+            if [ -n "$git_ref" ]; then
+                echo "Error: you have already entered value for --git-ref"
+                exit 1
+            else
+                git_ref=$2
+                use_remote=true
+                shift 2
+            fi
+            ;;
+
+        --remove-first)
+            if [ $remove_first = true ]; then
+                echo "Error: you have already entered --remove_first"
+                exit 1
+            else
+                remove_first=true
+                shift 1
+            fi
+            ;;
+
+        --workspace-path)
+            if [ -n "$workspace_path" ]; then
+                echo "Error: you have already entered value for --workspace-path"
+                exit 1
+            else
+                workspace_path=$2
+                shift 2
+            fi
+            ;;
+
+        -h | --help)
+            if [ $show_help = true ]; then
+                echo "Error: you have already entered -h, --help"
+                exit 1
+            else
+                show_help=true
+                HELP_ARG="$1"
+                shift 1
+            fi
+            ;;
+
+        -* | --* | *)
+            PKG_ARGS="$PKG_ARGS $1"
+            shift 1
+            ;;
+    esac
+done
+
+set -- $PKG_ARGS
+
+# use '/mnt/build/cloudstack' as default workspace path
+if [ -z "$workspace_path" ]; then
+    workspace_path="/mnt/build/cloudstack"
+fi
+
+# Both of --git-remote AND --git-ref must be specified at the same time
+if [ $use_remote = true ]; then
+    if [ -z "$git_remote" -o -z "$git_ref" ]; then
+        echo "Error: you must specify --git-remote and --git-ref at the same time"
+        exit 1
+    fi
+fi
+
+# Check if cloudstack directory exists or not. Options are either:
+#
+#   1) cloudstack directory is provided through the host's volume
+#   2) cloudstack directory is NOT provided and git remote and ref are provided
+#
+# Any combination of the above situations is invalid.
+if [ -d "${workspace_path}" ]; then
+    if [ $use_remote = true ]; then
+        if [ $remove_first = false ]; then
+            echo "Error: Could not clone remote git repository, '${workspace_path}' exists"
+            exit 1
+        else
+            echo -e "\e[0;32mremoving ${workspace_path} ...\e[0m"
+            rm -rf ${workspace_path}
+            echo ""
+        fi
+    fi
+else
+    if [ $use_remote = false ]; then
+        echo "Could not find '${workspace_path}'"
+        exit 1
+    fi
+fi
+
+# Print out some environment information
+environment-info.sh
+
+# Clone the remote provided git repo and ref
+if [ $use_remote = true ]; then
+    echo -e "\e[0;32mcloning $git_remote ...\e[0m"
+    git clone --quiet --depth=50 $git_remote ${workspace_path}
+    echo ""
+
+    cd ${workspace_path}
+
+    echo -e "\e[0;32mfetching $git_ref ...\e[0m"
+    git fetch --quiet origin +$git_ref:
+    echo ""
+
+    echo -e "\e[0;32mchecking out $git_ref ...\e[0m"
+    git checkout --quiet --force FETCH_HEAD
+    echo ""
+fi
+
+# Make sure build-deb.sh script exists before going any further
+if [ ! -f "${workspace_path}/packaging/build-deb.sh" ]; then
+    echo "Could not find '${workspace_path}/packaging/build-deb.sh'"
+    exit 1
+fi
+
+# convert LONG flags to SHORT flags for anything prior 4.12.x.x
+echo -e "\e[0;32mdetecting CloudStack version ...\e[0m"
+pom_version=$(cd ${workspace_path}; mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+echo "${pom_version}"
+major_version=$(echo ${pom_version} | cut -d. -f1)
+minor_version=$(echo ${pom_version} | cut -d. -f2)
+echo ""
+
+if [ $major_version -lt 4 ] || [ $major_version -eq 4 -a $minor_version -lt 12 ]; then
+    if [ $show_help = true ]; then
+        HELP_ARG=""
+    fi
+fi
+
+# Show help, both from docker-entrypoint.sh and ${workspace_path}/packaging/build-deb.sh
+if [ $show_help = true ]; then
+    if [ -n "$HELP_ARG" ]; then
+        help=$(cd ${workspace_path}/packaging; bash -x ./build-deb.sh $HELP_ARG)
+    else
+        help=""
+    fi
+    cat << USAGE
+Usage: docker run ... khos2ow/cloudstack-deb-builder [DOCKER_OPTIONS] ... [PACKAGING_OPTIONS]...
+CloudStack DEB builder which acts as a wrapper for CloudStack package script. Optionally
+you can  specify remote git repository and ref to  be cloned and checked out and run the
+packaging script on in.
+
+Optional arguments:
+   --git-remote string                     Set the git remote repository to clone (must be set together with \`--git-ref\`) (default: none)
+   --git-ref string                        Set the ref from remote repository to check out (must be set together with \`--git-remote\`) (default: none)
+   --remove-first                          Remove existing \`${workspace_path}\` directory before cloning (default: false)
+   --workspace-path string                 Set the directory path of workspace to work with (default: \`/mnt/build/cloudstack\`)
+
+Other arguments:
+   -h, --help                              Display this help message and exit
+
+Examples:
+   docker run ... khos2ow/cloudstack-deb-builder [PACKAGING_OPTIONS] ...
+   docker run ... khos2ow/cloudstack-deb-builder --git-remote https://path.to.repo/cloudstack.git --git-ref foo-branch [PACKAGING_OPTIONS] ...
+
+--------
+
+$help
+
+USAGE
+    exit 0
+fi
+
+# Adjust user and group provided by host
+function adjust_owner() {
+    # if both set then change the owner
+    if [ -n "${USER_ID}" -a -z "${USER_GID}" ]; then
+        chown -R ${USER_ID} ${workspace_path}
+    elif [ -n "${USER_ID}" -a -n "${USER_GID}" ]; then
+        chown -R ${USER_ID}:${USER_GID} ${workspace_path}
+    fi
+}
+
+{
+    cd ${workspace_path}/packaging
+
+    echo -e "\e[0;32mpackaging CloudStack DEB packages ...\e[0m"
+
+    # do the packaging
+    bash -x ./build-deb.sh $@ && {
+        mkdir -p ${workspace_path}/dist/debbuild/DEBS
+
+        cp ${workspace_path}/../cloudstack-*.deb ${workspace_path}/dist/debbuild/DEBS
+        cp ${workspace_path}/../cloudstack_*.changes ${workspace_path}/dist/debbuild/DEBS
+
+        adjust_owner
+    }
+} || {
+    status=$?
+
+    adjust_owner
+    echo "Packaging DEB failed"
+    exit $status
+}

--- a/ubuntu1804-jdk11/environment-info.sh
+++ b/ubuntu1804-jdk11/environment-info.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+EXTRA_LINE=""
+
+print_title() {
+    local version_label=""
+    if [[ "$1" = *":" ]]; then
+        version_label=""
+    else
+        version_label=" version:"
+    fi
+    echo -e "${EXTRA_LINE}\e[1;34m$1${version_label}\e[0m"
+}
+
+print_title "system information:"
+cat /etc/*-release
+
+EXTRA_LINE="\n"
+
+print_title "git"
+git --version
+
+print_title "java"
+java -version
+
+print_title "maven"
+mvn --version
+
+print_title "python"
+python --version
+
+print_title "dpkg"
+dpkg --version
+
+print_title "devscripts"
+dpkg -s devscripts | grep "Version:" | awk '{print $2}'
+
+print_title "debhelper"
+dpkg -s debhelper | grep "Version:" | awk '{print $2}'
+
+print_title "genisoimage"
+genisoimage --version
+
+print_title "lsb-release"
+dpkg -s lsb-release | grep "Version:" | awk '{print $2}'
+
+print_title "build-essential"
+dpkg -s build-essential | grep "Version:" | awk '{print $2}'
+
+echo ""


### PR DESCRIPTION
ACS 4.14+ requires `java 11`.

In the test of `ubuntu1804`, it was retrieving the `ACS' master ref`, but master now needs `java 11`; therefore, I changed it to `4.13`, which is the last with `java 8`.

Further, I created a new test to `ubuntu1804-jdk11` with `ACS 4.15`. This version is using a new UI as default. This UI was built with VUE so it is going to need `nodejs (12+)` dependency too.