### PR TITLE
add Ubuntu 20.04 Image and JDK11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,31 @@ jobs:
         if: contains(github.ref, 'refs/heads/master') && env.REGISTRY_USERNAME != ''
         run: DOCKER_TAG=ubuntu1804-jdk11 make push
 
+  ubuntu2004-jdk11:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build ubuntu2004-jdk11
+        run: make ubuntu2004-jdk11
+
+      - name: Test ubuntu2004-jdk11
+        if: "!contains(github.ref, 'refs/heads/master')"
+        run: ./scripts/test.sh ubuntu2004-jdk11 refs/heads/4.15 ""
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: contains(github.ref, 'refs/heads/master') && env.REGISTRY_USERNAME != ''
+        with:
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Push ubuntu2004-jdk11
+        if: contains(github.ref, 'refs/heads/master') && env.REGISTRY_USERNAME != ''
+        run: DOCKER_TAG=ubuntu2004-jdk11 make push
+        
   latest:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ define build_tag
 endef
 
 .PHONY: all
-all: ubuntu1404 ubuntu1604 ubuntu1804 ubuntu1804-jdk11 latest
+all: ubuntu1404 ubuntu1604 ubuntu1804 ubuntu1804-jdk11 ubuntu2004-jdk11 latest
 
 .PHONY: ubuntu1404
 ubuntu1404: ## Build ubuntu1404 image
@@ -53,10 +53,15 @@ ubuntu1804-jdk11: ## Build ubuntu1804-jdk11 image
 	@ $(MAKE) --no-print-directory log-$@
 	$(call build_tag,ubuntu1804-jdk11,ubuntu1804-jdk11)
 
+.PHONY: ubuntu2004-jdk11
+ubuntu2004-jdk11: ## Build ubuntu2004-jdk11 image
+	@ $(MAKE) --no-print-directory log-$@
+	$(call build_tag,ubuntu2004-jdk11,ubuntu2004-jdk11)
+
 .PHONY: latest
 latest: ## Build latest image
 	@ $(MAKE) --no-print-directory log-$@
-	$(call build_tag,latest,ubuntu1804)
+	$(call build_tag,latest,ubuntu2004-jdk11)
 
 .PHONY: push
 push: DOCKER_TAG ?=

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ for releases. A very good candidate to be used by the Jenkins slaves of the proj
 
 ## Supported tags and respective `Dockerfile` links
 
-- [`latest`, `ubuntu1804` (ubuntu1804/Dockerfile)][latest-dockerfile]
+- [`latest`, `ubuntu2004-jdk11` (ubuntu2004-jdk11/Dockerfile)][latest-dockerfile]
+- [`ubuntu2004-jdk11` (ubuntu2004-jdk11/Dockerfile)][ubuntu2004-jdk11-dockerfile]
 - [`ubuntu1804-jdk11` (ubuntu1804-jdk11/Dockerfile)][ubuntu1804-jdk11-dockerfile]
+- [`ubuntu1804` (ubuntu1804/Dockerfile)][ubuntu1804-jdk11-dockerfile]
 - [`ubuntu1604` (ubuntu1604/Dockerfile)][ubuntu1604-dockerfile]
 - [`ubuntu1404` (ubuntu1404/Dockerfile)][ubuntu1404-dockerfile]
 
@@ -57,14 +59,14 @@ required:
 
 ### Pull Docker images
 
-Let's assume we want to build packages for Ubuntu 16.04 (Xenial). We pull that
+Let's assume we want to build packages for Ubuntu 20.04 (Focal). We pull that
 image first:
 
 ```bashe
-docker pull khos2ow/cloudstack-deb-builder:ubuntu1604
+docker pull khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11
 ```
 
-You can replace `ubuntu1604` tag by `ubuntu1804`, `ubuntu1404` or `latest` if
+You can replace `ubuntu2004-jdk11` tag by `ubuntu1804`, `ubuntu1404` or `latest` if
 you want.
 
 ### Build local repository
@@ -92,7 +94,7 @@ always expects the `cloudstack` code exists in `/mnt/build` path.)
 ```bash
 docker run \
     -v /tmp:/mnt/build \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 [ARGS...]
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 [ARGS...]
 ```
 
 Or if your local cloudstack folder has other name, you need to map it to
@@ -101,7 +103,7 @@ Or if your local cloudstack folder has other name, you need to map it to
 ```bash
 docker run \
     -v /tmp/cloudstack-custom-name:/mnt/build/cloudstack \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 [ARGS...]
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 [ARGS...]
 ```
 
 After the build has finished the `.deb` packages are available in
@@ -125,7 +127,7 @@ in `/mnt/build/cloudstack` inside the container and can be accessed from
 ```bash
 docker run \
     -v /tmp:/mnt/build \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 \
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 \
         --git-remote https://github.com/apache/cloudstack.git \
         --git-ref master \
         [ARGS...]
@@ -155,7 +157,7 @@ it run faster.
 docker run \
     -v /tmp:/mnt/build \
     -v ~/.m2:/root/.m2 \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 [ARGS...]
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 [ARGS...]
 ```
 
 ### Adjust host owner permission
@@ -175,7 +177,7 @@ docker run \
     -v /tmp:/mnt/build \
     -e "USER_ID=$(id -u)" \
     -e "USER_GID=$(id -g)" \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 [ARGS...]
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 [ARGS...]
 ```
 
 ## Builder help
@@ -185,7 +187,7 @@ To see all the available options you can pass to `docker run ...` command:
 ```bash
 docker run \
     -v /tmp:/mnt/build \
-    khos2ow/cloudstack-deb-builder:ubuntu1604 --help
+    khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11 --help
 ```
 
 ## License
@@ -198,5 +200,6 @@ included in the root directory of the source tree for extended license details.
 [latest-dockerfile]: https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1804/Dockerfile
 [ubuntu1404-dockerfile]: https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1404/Dockerfile
 [ubuntu1604-dockerfile]: https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1604/Dockerfile
+[ubuntu2004-dockerfile]: https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu2004-jdk11/Dockerfile
 [ubuntu1804-jdk11-dockerfile]: https://github.com/khos2ow/cloudstack-deb-builder/blob/master/ubuntu1804-jdk11/Dockerfile
 [https://github.com/apache/cloudstack]: https://github.com/apache/cloudstack

--- a/ubuntu2004-jdk11/Dockerfile
+++ b/ubuntu2004-jdk11/Dockerfile
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:20.04
+LABEL maintainer="Khosrow Moossavi <me@khosrow.io> (@khos2ow)"
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        locate \
+        tar \
+        lsb-release \
+        build-essential \
+        dpkg-dev \
+        devscripts \
+        debhelper \
+        genisoimage \
+        git \
+        maven \
+        openjdk-11-jdk \
+        python \
+        python3-mysqldb \
+        python3-mysql.connector \
+        dh-systemd \
+        python-setuptools \
+        curl \
+        sudo && \
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash - && \
+    apt-get install -y --no-install-recommends \
+        nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    update-java-alternatives -s java-1.11.0-openjdk-amd64
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+
+VOLUME /mnt/build
+WORKDIR /mnt/build
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY environment-info.sh /usr/local/bin/environment-info.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/ubuntu2004-jdk11/docker-entrypoint.sh
+++ b/ubuntu2004-jdk11/docker-entrypoint.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# Flag to show help text
+show_help=false
+
+# Workspace path
+workspace_path=""
+
+# Using remote git repository variables
+use_remote=false
+git_remote=""
+git_ref=""
+remove_first=false
+
+# packaging flags to be sent to script
+PKG_ARGS=""
+HELP_ARG=""
+
+while [ -n "$1" ]; do
+    case "$1" in
+        --git-remote)
+            if [ -n "$git_remote" ]; then
+                echo "Error: you have already entered value for --git-remote"
+                exit 1
+            else
+                git_remote=$2
+                use_remote=true
+                shift 2
+            fi
+            ;;
+
+        --git-ref)
+            if [ -n "$git_ref" ]; then
+                echo "Error: you have already entered value for --git-ref"
+                exit 1
+            else
+                git_ref=$2
+                use_remote=true
+                shift 2
+            fi
+            ;;
+
+        --remove-first)
+            if [ $remove_first = true ]; then
+                echo "Error: you have already entered --remove_first"
+                exit 1
+            else
+                remove_first=true
+                shift 1
+            fi
+            ;;
+
+        --workspace-path)
+            if [ -n "$workspace_path" ]; then
+                echo "Error: you have already entered value for --workspace-path"
+                exit 1
+            else
+                workspace_path=$2
+                shift 2
+            fi
+            ;;
+
+        -h | --help)
+            if [ $show_help = true ]; then
+                echo "Error: you have already entered -h, --help"
+                exit 1
+            else
+                show_help=true
+                HELP_ARG="$1"
+                shift 1
+            fi
+            ;;
+
+        -* | --* | *)
+            PKG_ARGS="$PKG_ARGS $1"
+            shift 1
+            ;;
+    esac
+done
+
+set -- $PKG_ARGS
+
+# use '/mnt/build/cloudstack' as default workspace path
+if [ -z "$workspace_path" ]; then
+    workspace_path="/mnt/build/cloudstack"
+fi
+
+# Both of --git-remote AND --git-ref must be specified at the same time
+if [ $use_remote = true ]; then
+    if [ -z "$git_remote" -o -z "$git_ref" ]; then
+        echo "Error: you must specify --git-remote and --git-ref at the same time"
+        exit 1
+    fi
+fi
+
+# Check if cloudstack directory exists or not. Options are either:
+#
+#   1) cloudstack directory is provided through the host's volume
+#   2) cloudstack directory is NOT provided and git remote and ref are provided
+#
+# Any combination of the above situations is invalid.
+if [ -d "${workspace_path}" ]; then
+    if [ $use_remote = true ]; then
+        if [ $remove_first = false ]; then
+            echo "Error: Could not clone remote git repository, '${workspace_path}' exists"
+            exit 1
+        else
+            echo -e "\e[0;32mremoving ${workspace_path} ...\e[0m"
+            rm -rf ${workspace_path}
+            echo ""
+        fi
+    fi
+else
+    if [ $use_remote = false ]; then
+        echo "Could not find '${workspace_path}'"
+        exit 1
+    fi
+fi
+
+# Print out some environment information
+environment-info.sh
+
+# Clone the remote provided git repo and ref
+if [ $use_remote = true ]; then
+    echo -e "\e[0;32mcloning $git_remote ...\e[0m"
+    git clone --quiet --depth=50 $git_remote ${workspace_path}
+    echo ""
+
+    cd ${workspace_path}
+
+    echo -e "\e[0;32mfetching $git_ref ...\e[0m"
+    git fetch --quiet origin +$git_ref:
+    echo ""
+
+    echo -e "\e[0;32mchecking out $git_ref ...\e[0m"
+    git checkout --quiet --force FETCH_HEAD
+    echo ""
+fi
+
+# Make sure build-deb.sh script exists before going any further
+if [ ! -f "${workspace_path}/packaging/build-deb.sh" ]; then
+    echo "Could not find '${workspace_path}/packaging/build-deb.sh'"
+    exit 1
+fi
+
+# convert LONG flags to SHORT flags for anything prior 4.12.x.x
+echo -e "\e[0;32mdetecting CloudStack version ...\e[0m"
+pom_version=$(cd ${workspace_path}; mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+echo "${pom_version}"
+major_version=$(echo ${pom_version} | cut -d. -f1)
+minor_version=$(echo ${pom_version} | cut -d. -f2)
+echo ""
+
+if [ $major_version -lt 4 ] || [ $major_version -eq 4 -a $minor_version -lt 12 ]; then
+    if [ $show_help = true ]; then
+        HELP_ARG=""
+    fi
+fi
+
+# Show help, both from docker-entrypoint.sh and ${workspace_path}/packaging/build-deb.sh
+if [ $show_help = true ]; then
+    if [ -n "$HELP_ARG" ]; then
+        help=$(cd ${workspace_path}/packaging; bash -x ./build-deb.sh $HELP_ARG)
+    else
+        help=""
+    fi
+    cat << USAGE
+Usage: docker run ... khos2ow/cloudstack-deb-builder [DOCKER_OPTIONS] ... [PACKAGING_OPTIONS]...
+CloudStack DEB builder which acts as a wrapper for CloudStack package script. Optionally
+you can  specify remote git repository and ref to  be cloned and checked out and run the
+packaging script on in.
+
+Optional arguments:
+   --git-remote string                     Set the git remote repository to clone (must be set together with \`--git-ref\`) (default: none)
+   --git-ref string                        Set the ref from remote repository to check out (must be set together with \`--git-remote\`) (default: none)
+   --remove-first                          Remove existing \`${workspace_path}\` directory before cloning (default: false)
+   --workspace-path string                 Set the directory path of workspace to work with (default: \`/mnt/build/cloudstack\`)
+
+Other arguments:
+   -h, --help                              Display this help message and exit
+
+Examples:
+   docker run ... khos2ow/cloudstack-deb-builder [PACKAGING_OPTIONS] ...
+   docker run ... khos2ow/cloudstack-deb-builder --git-remote https://path.to.repo/cloudstack.git --git-ref foo-branch [PACKAGING_OPTIONS] ...
+
+--------
+
+$help
+
+USAGE
+    exit 0
+fi
+
+# Adjust user and group provided by host
+function adjust_owner() {
+    # if both set then change the owner
+    if [ -n "${USER_ID}" -a -z "${USER_GID}" ]; then
+        chown -R ${USER_ID} ${workspace_path}
+    elif [ -n "${USER_ID}" -a -n "${USER_GID}" ]; then
+        chown -R ${USER_ID}:${USER_GID} ${workspace_path}
+    fi
+}
+
+{
+    cd ${workspace_path}/packaging
+
+    echo -e "\e[0;32mpackaging CloudStack DEB packages ...\e[0m"
+
+    # do the packaging
+    bash -x ./build-deb.sh $@ && {
+        mkdir -p ${workspace_path}/dist/debbuild/DEBS
+
+        cp ${workspace_path}/../cloudstack-*.deb ${workspace_path}/dist/debbuild/DEBS
+        cp ${workspace_path}/../cloudstack_*.changes ${workspace_path}/dist/debbuild/DEBS
+
+        adjust_owner
+    }
+} || {
+    status=$?
+
+    adjust_owner
+    echo "Packaging DEB failed"
+    exit $status
+}

--- a/ubuntu2004-jdk11/environment-info.sh
+++ b/ubuntu2004-jdk11/environment-info.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+EXTRA_LINE=""
+
+print_title() {
+    local version_label=""
+    if [[ "$1" = *":" ]]; then
+        version_label=""
+    else
+        version_label=" version:"
+    fi
+    echo -e "${EXTRA_LINE}\e[1;34m$1${version_label}\e[0m"
+}
+
+print_title "system information:"
+cat /etc/*-release
+
+EXTRA_LINE="\n"
+
+print_title "git"
+git --version
+
+print_title "java"
+java -version
+
+print_title "maven"
+mvn --version
+
+print_title "python"
+python --version
+
+print_title "dpkg"
+dpkg --version
+
+print_title "devscripts"
+dpkg -s devscripts | grep "Version:" | awk '{print $2}'
+
+print_title "debhelper"
+dpkg -s debhelper | grep "Version:" | awk '{print $2}'
+
+print_title "genisoimage"
+genisoimage --version
+
+print_title "lsb-release"
+dpkg -s lsb-release | grep "Version:" | awk '{print $2}'
+
+print_title "build-essential"
+dpkg -s build-essential | grep "Version:" | awk '{print $2}'
+
+echo ""


### PR DESCRIPTION
Since we need JDK11 to build ACS 4.14+
This PR propose to introduce to support Ubuntu 20.04 (Focal) with Java Development Kit. 
Some packages was changed to its substitute in python3

A simple log message to show successful image creation
```
Successfully built 462577c5a947
Successfully tagged khos2ow/cloudstack-deb-builder:ubuntu2004-jdk11
```
